### PR TITLE
Add gradle.properties for toolchain auto download

### DIFF
--- a/HackerPlatform-Backend/gradle.properties
+++ b/HackerPlatform-Backend/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.java.installations.auto-download=true


### PR DESCRIPTION
## Summary
- add `gradle.properties` so Gradle will download missing JDKs automatically

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68684f2affc883238e8fa5d8cfa5696e