### PR TITLE
Add user model and service

### DIFF
--- a/HackerPlatform-Backend/build.gradle
+++ b/HackerPlatform-Backend/build.gradle
@@ -18,10 +18,12 @@ java {
 repositories { mavenCentral() }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
-	implementation 'org.springframework.security:spring-security-oauth2-jose:6.5.1'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        implementation 'org.springframework.boot:spring-boot-starter-security'
+        implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+        runtimeOnly 'com.h2database:h2'
+        implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+        implementation 'org.springframework.security:spring-security-oauth2-jose:6.5.1'
 
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/auth/AuthController.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/auth/AuthController.java
@@ -1,23 +1,19 @@
 package com.myorg.hackerplatform.auth;
 
-import com.myorg.hackerplatform.jwt.JwtUtil;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
+import com.myorg.hackerplatform.service.AuthService;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
-    @Autowired private AuthenticationManager authManager;
-    @Autowired private JwtUtil jwtUtil;
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
 
     @PostMapping("/login")
     public String login(@RequestBody AuthRequest req) {
-        Authentication auth = authManager.authenticate(
-                new UsernamePasswordAuthenticationToken(req.getUsername(), req.getPassword())
-        );
-        return jwtUtil.generateToken(auth.getName());
+        return authService.login(req.getUsername(), req.getPassword());
     }
 }

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/model/User.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/model/User.java
@@ -1,0 +1,40 @@
+package com.myorg.hackerplatform.model;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String username;
+
+    private String password;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/repository/UserRepository.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.myorg.hackerplatform.repository;
+
+import com.myorg.hackerplatform.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/service/AuthService.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/service/AuthService.java
@@ -1,0 +1,25 @@
+package com.myorg.hackerplatform.service;
+
+import com.myorg.hackerplatform.jwt.JwtUtil;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+    private final AuthenticationManager authManager;
+    private final JwtUtil jwtUtil;
+
+    public AuthService(AuthenticationManager authManager, JwtUtil jwtUtil) {
+        this.authManager = authManager;
+        this.jwtUtil = jwtUtil;
+    }
+
+    public String login(String username, String password) {
+        Authentication auth = authManager.authenticate(
+                new UsernamePasswordAuthenticationToken(username, password)
+        );
+        return jwtUtil.generateToken(auth.getName());
+    }
+}

--- a/HackerPlatform-Backend/src/main/resources/application.properties
+++ b/HackerPlatform-Backend/src/main/resources/application.properties
@@ -6,3 +6,8 @@ jwt.expirationMs=3600000
 
 # Spring Security OAuth2 Resource Server (decoding JWTs)
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8080
+
+# JPA and H2 configuration
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driverClassName=org.h2.Driver
+spring.jpa.hibernate.ddl-auto=update

--- a/README.md
+++ b/README.md
@@ -6,6 +6,16 @@ Your Cyber Hacker
 - **JDK 21** – the build uses the Java 21 toolchain defined in `build.gradle`.
 - **Gradle Wrapper** – use the provided `./gradlew` script inside the `HackerPlatform-Backend` directory.
 
+## Building
+
+From `HackerPlatform-Backend` run:
+
+```bash
+./gradlew build
+```
+
+This compiles the source and packages the jar under `build/libs/`.
+
 ## Running Tests
 
 From `HackerPlatform-Backend` run:


### PR DESCRIPTION
## Summary
- add a `User` entity with JPA annotations
- create `UserRepository` for DB access
- implement `AuthService` to handle authentication
- refactor `AuthController` to delegate to `AuthService`
- enable Spring Data JPA and H2 database configuration

## Testing
- `./gradlew test`
- `timeout 15 ./gradlew bootRun`

------
https://chatgpt.com/codex/tasks/task_e_68684f2c720083239cf21760086b3936