### PR TITLE
Add API_URL configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,15 @@ npm run dev
 ```
 
 This starts the app locally with hot reload enabled.
+
+### Configuring API_URL
+
+API requests from the UI rely on the `API_URL` environment variable. Create a
+`.env.local` file inside `HackerPlatform-UI` with the following contents:
+
+```bash
+API_URL=http://localhost:8080
+```
+
+Replace the URL with the address of your backend if different. The Next.js app
+will pick up this variable when you run `npm run dev`.


### PR DESCRIPTION
## Summary
- document how to configure the Next.js app's `API_URL`

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation on your machine)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6868642a9d40832381771b133691c284