### PR TITLE
Use env var for JWT secret

### DIFF
--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/jwt/JwtUtil.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/jwt/JwtUtil.java
@@ -11,7 +11,7 @@ import java.util.Date;
 
 @Service
 public class JwtUtil {
-    @Value("${jwt.secret}")
+    @Value("${JWT_SECRET}")
     private String secret;
     @Value("${jwt.expirationMs}")
     private int expirationMs;

--- a/HackerPlatform-Backend/src/main/resources/application.properties
+++ b/HackerPlatform-Backend/src/main/resources/application.properties
@@ -1,7 +1,6 @@
 spring.application.name=HackerPlatform-Backend
 
 # JWT configuration
-jwt.secret= lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=
 jwt.expirationMs=3600000
 
 # Spring Security OAuth2 Resource Server (decoding JWTs)

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ To start the Spring Boot application execute:
 
 The service will start locally on the default port.
 
+## Configuration
+
+Set the backend JWT signing secret via the `JWT_SECRET` environment variable before running:
+
+```bash
+export JWT_SECRET=<your-base64-secret>
+```
+
 ## Frontend Development
 
 The Next.js UI lives under `HackerPlatform-UI`.


### PR DESCRIPTION
## Summary
- remove `jwt.secret` from `application.properties`
- inject JWT secret using the `JWT_SECRET` environment variable
- document JWT secret configuration in the README

## Testing
- `./gradlew test` *(fails: Cannot find a Java installation matching languageVersion=24)*

------
https://chatgpt.com/codex/tasks/task_e_686864a4cc64832397fec6d2e096b9b1