### PR TITLE
Configure JwtDecoder bean

### DIFF
--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/config/SecurityConfig.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.myorg.hackerplatform.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -9,6 +10,12 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+import javax.crypto.SecretKey;
 
 @Configuration
 public class SecurityConfig {
@@ -33,5 +40,11 @@ public class SecurityConfig {
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
         return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public JwtDecoder jwtDecoder(@Value("${jwt.secret}") String secret) {
+        SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+        return NimbusJwtDecoder.withSecretKey(key).build();
     }
 }

--- a/HackerPlatform-Backend/src/main/resources/application.properties
+++ b/HackerPlatform-Backend/src/main/resources/application.properties
@@ -5,7 +5,6 @@ jwt.secret= lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=
 jwt.expirationMs=3600000
 
 # Spring Security OAuth2 Resource Server (decoding JWTs)
-spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8080
 
 # JPA and H2 configuration
 spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE


### PR DESCRIPTION
## Summary
- remove unused issuer URI
- provide a JwtDecoder that uses the same secret as JwtUtil

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find a Java installation matching 24)*

------
https://chatgpt.com/codex/tasks/task_e_6868638488bc8323a6c76007bc1cf5c0