### PR TITLE
Add Node build directories to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,17 @@ build/
 # Output directories
 out/
 bin/
+
+# Node.js
+HackerPlatform-UI/node_modules/
+.next/
+HackerPlatform-UI/.next/
+*.log
+# npm/TypeScript caches
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.eslintcache
+.turbo/
+.pnpm-store/


### PR DESCRIPTION
## Summary
- ignore runtime build logs and Node.js output
- ignore UI `node_modules` and `.next` directories
- ignore optional npm/TypeScript caches

## Testing
- `./gradlew test --no-daemon` *(fails: Could not find a Java installation)*

------
https://chatgpt.com/codex/tasks/task_e_686864276f7c8323b554eef2e65c0157