### PR TITLE
Add refresh token flow

### DIFF
--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/auth/AuthController.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/auth/AuthController.java
@@ -3,6 +3,8 @@ package com.myorg.hackerplatform.auth;
 import com.myorg.hackerplatform.service.AuthService;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/api/auth")
 public class AuthController {
@@ -13,7 +15,20 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public String login(@RequestBody AuthRequest req) {
+    public Map<String, String> login(@RequestBody AuthRequest req) {
         return authService.login(req.getUsername(), req.getPassword());
+    }
+
+    @PostMapping("/refresh")
+    public Map<String, String> refresh(@RequestBody Map<String, String> body) {
+        String refreshToken = body.get("refreshToken");
+        String accessToken = authService.refresh(refreshToken);
+        return Map.of("accessToken", accessToken);
+    }
+
+    @PostMapping("/logout")
+    public void logout(@RequestBody Map<String, String> body) {
+        String refreshToken = body.get("refreshToken");
+        authService.logout(refreshToken);
     }
 }

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/model/RefreshToken.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/model/RefreshToken.java
@@ -1,0 +1,33 @@
+package com.myorg.hackerplatform.model;
+
+import jakarta.persistence.*;
+import java.util.Date;
+
+@Entity
+@Table(name = "refresh_tokens")
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private Date expiryDate;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getToken() { return token; }
+    public void setToken(String token) { this.token = token; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public Date getExpiryDate() { return expiryDate; }
+    public void setExpiryDate(Date expiryDate) { this.expiryDate = expiryDate; }
+}

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/repository/RefreshTokenRepository.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.myorg.hackerplatform.repository;
+
+import com.myorg.hackerplatform.model.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+    void deleteByToken(String token);
+}

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/service/AuthService.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/service/AuthService.java
@@ -1,25 +1,72 @@
 package com.myorg.hackerplatform.service;
 
 import com.myorg.hackerplatform.jwt.JwtUtil;
+import com.myorg.hackerplatform.model.RefreshToken;
+import com.myorg.hackerplatform.model.User;
+import com.myorg.hackerplatform.repository.RefreshTokenRepository;
+import com.myorg.hackerplatform.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 @Service
 public class AuthService {
     private final AuthenticationManager authManager;
     private final JwtUtil jwtUtil;
+    private final RefreshTokenRepository refreshRepo;
+    private final UserRepository userRepo;
 
-    public AuthService(AuthenticationManager authManager, JwtUtil jwtUtil) {
+    @Value("${jwt.refreshExpirationMs}")
+    private int refreshExpirationMs;
+
+    public AuthService(AuthenticationManager authManager, JwtUtil jwtUtil,
+                       RefreshTokenRepository refreshRepo, UserRepository userRepo) {
         this.authManager = authManager;
         this.jwtUtil = jwtUtil;
+        this.refreshRepo = refreshRepo;
+        this.userRepo = userRepo;
     }
 
-    public String login(String username, String password) {
+    public Map<String, String> login(String username, String password) {
         Authentication auth = authManager.authenticate(
                 new UsernamePasswordAuthenticationToken(username, password)
         );
-        return jwtUtil.generateToken(auth.getName());
+        String accessToken = jwtUtil.generateToken(auth.getName());
+        String refreshToken = createRefreshToken(auth.getName());
+        Map<String, String> tokens = new HashMap<>();
+        tokens.put("accessToken", accessToken);
+        tokens.put("refreshToken", refreshToken);
+        return tokens;
+    }
+
+    private String createRefreshToken(String username) {
+        User user = userRepo.findByUsername(username).orElseThrow();
+        RefreshToken token = new RefreshToken();
+        token.setUser(user);
+        token.setToken(UUID.randomUUID().toString());
+        token.setExpiryDate(new Date(System.currentTimeMillis() + refreshExpirationMs));
+        refreshRepo.save(token);
+        return token.getToken();
+    }
+
+    public String refresh(String refreshToken) {
+        RefreshToken token = refreshRepo.findByToken(refreshToken)
+                .orElseThrow(() -> new RuntimeException("Invalid refresh token"));
+        if (token.getExpiryDate().before(new Date())) {
+            refreshRepo.delete(token);
+            throw new RuntimeException("Expired refresh token");
+        }
+        return jwtUtil.generateToken(token.getUser().getUsername());
+    }
+
+    public void logout(String refreshToken) {
+        refreshRepo.deleteByToken(refreshToken);
     }
 }

--- a/HackerPlatform-Backend/src/main/resources/application.properties
+++ b/HackerPlatform-Backend/src/main/resources/application.properties
@@ -3,6 +3,7 @@ spring.application.name=HackerPlatform-Backend
 # JWT configuration
 jwt.secret= lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=
 jwt.expirationMs=3600000
+jwt.refreshExpirationMs=86400000
 
 # Spring Security OAuth2 Resource Server (decoding JWTs)
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8080

--- a/HackerPlatform-UI/app/api/auth/login/route.ts
+++ b/HackerPlatform-UI/app/api/auth/login/route.ts
@@ -8,8 +8,14 @@ export async function POST(req: Request) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username, password })
   });
-  const token = await res.text();
-  cookies().set('accessToken', token, {
+  const { accessToken, refreshToken } = await res.json();
+  cookies().set('accessToken', accessToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+    path: '/'
+  });
+  cookies().set('refreshToken', refreshToken, {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'strict',

--- a/HackerPlatform-UI/app/api/auth/logout/route.ts
+++ b/HackerPlatform-UI/app/api/auth/logout/route.ts
@@ -1,0 +1,16 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  const refreshToken = cookies().get('refreshToken')?.value;
+  if (refreshToken) {
+    await fetch(`${process.env.API_URL}/api/auth/logout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refreshToken })
+    });
+  }
+  cookies().delete('accessToken');
+  cookies().delete('refreshToken');
+  return NextResponse.json({ success: true });
+}

--- a/HackerPlatform-UI/app/api/auth/refresh/route.ts
+++ b/HackerPlatform-UI/app/api/auth/refresh/route.ts
@@ -1,0 +1,25 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  const refreshToken = cookies().get('refreshToken')?.value;
+  if (!refreshToken) {
+    return NextResponse.json({ error: 'No refresh token' }, { status: 400 });
+  }
+  const res = await fetch(`${process.env.API_URL}/api/auth/refresh`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refreshToken })
+  });
+  if (!res.ok) {
+    return NextResponse.json({ error: 'Failed to refresh' }, { status: res.status });
+  }
+  const { accessToken } = await res.json();
+  cookies().set('accessToken', accessToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+    path: '/'
+  });
+  return NextResponse.json({ success: true });
+}


### PR DESCRIPTION
## Summary
- add `RefreshToken` JPA entity and repository
- generate and store refresh tokens on login
- support refresh and logout endpoints
- handle refresh tokens in the Next.js login logic
- expose frontend routes for refresh and logout

## Testing
- `./gradlew build -x test` *(fails: Cannot find a Java installation matching: languageVersion=24)*

------
https://chatgpt.com/codex/tasks/task_e_6868642c08348323892f1b7ec3ff9069