### PR TITLE
Integrate repository-based user details

### DIFF
--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/config/SecurityConfig.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/config/SecurityConfig.java
@@ -3,12 +3,15 @@ package com.myorg.hackerplatform.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.config.annotation.web.configurers.oauth2.server.resource.OAuth2ResourceServerConfigurer;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class SecurityConfig {
@@ -29,7 +32,16 @@ public class SecurityConfig {
     }
 
     @Bean
-    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
-        return configuration.getAuthenticationManager();
+    public AuthenticationManager authenticationManager(HttpSecurity http,
+                                                       PasswordEncoder passwordEncoder,
+                                                       UserDetailsService userDetailsService) throws Exception {
+        AuthenticationManagerBuilder authBuilder = http.getSharedObject(AuthenticationManagerBuilder.class);
+        authBuilder.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder);
+        return authBuilder.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/service/CustomUserDetailsService.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/service/CustomUserDetailsService.java
@@ -1,0 +1,27 @@
+package com.myorg.hackerplatform.service;
+
+import com.myorg.hackerplatform.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByUsername(username)
+                .map(u -> User.withUsername(u.getUsername())
+                        .password(u.getPassword())
+                        .authorities("USER")
+                        .build())
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+    }
+}

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/HackerPlatformBackendApplicationTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/HackerPlatformBackendApplicationTests.java
@@ -3,7 +3,7 @@ package com.myorg.hackerplatform;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(properties = "JWT_SECRET=dummy")
 class HackerPlatformBackendApplicationTests {
 
 	@Test

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerVerifyTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerVerifyTests.java
@@ -21,7 +21,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(AuthControllerVerifyTests.TestConfig.class)
-@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000"})
+@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000"})
 class AuthControllerVerifyTests {
 
     @Autowired


### PR DESCRIPTION
## Summary
- provide `CustomUserDetailsService` backed by `UserRepository`
- use BCrypt password encoder
- wire `SecurityConfig` with custom user details service
- ensure tests supply JWT secret

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_686869f0584883239344cd669dced1b7