### PR TITLE
Add login page

### DIFF
--- a/HackerPlatform-UI/app/login/page.tsx
+++ b/HackerPlatform-UI/app/login/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password })
+    });
+    if (res.ok) {
+      router.push('/dashboard');
+    } else {
+      setError('Login failed');
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label htmlFor="username">Username:</label>
+        <input
+          id="username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+      </div>
+      <div>
+        <label htmlFor="password">Password:</label>
+        <input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </div>
+      {error && <p>{error}</p>}
+      <button type="submit">Login</button>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- add a login page with a form for username/password
- POST credentials to `/api/auth/login`
- redirect to `/dashboard` after a successful login

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68686bae1ed4832388a2c8bae16767db