### PR TITLE
Add auth login tests

### DIFF
--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerLoginTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerLoginTests.java
@@ -1,0 +1,55 @@
+package com.myorg.hackerplatform.auth;
+
+import com.myorg.hackerplatform.jwt.JwtUtil;
+import com.myorg.hackerplatform.service.AuthService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(AuthControllerLoginTests.TestConfig.class)
+@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000"})
+class AuthControllerLoginTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @Test
+    void loginValidUserReturns200() throws Exception {
+        when(authService.login(eq("alice"), eq("password"))).thenReturn("token");
+
+        mockMvc.perform(post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"username\":\"alice\",\"password\":\"password\"}"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("token"));
+    }
+
+    static class TestConfig {
+        @Bean
+        JwtUtil jwtUtil() {
+            JwtUtil util = new JwtUtil();
+            ReflectionTestUtils.setField(util, "secret", "lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=");
+            ReflectionTestUtils.setField(util, "expirationMs", 3600000);
+            return util;
+        }
+    }
+}

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/service/AuthServiceLoginTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/service/AuthServiceLoginTests.java
@@ -1,0 +1,24 @@
+package com.myorg.hackerplatform.service;
+
+import com.myorg.hackerplatform.jwt.JwtUtil;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AuthServiceLoginTests {
+
+    @Test
+    void loginReturnsValidJwtForCorrectCredentials() {
+        AuthenticationManager manager = authentication -> authentication;
+        JwtUtil jwtUtil = new JwtUtil();
+        ReflectionTestUtils.setField(jwtUtil, "secret", "lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=");
+        ReflectionTestUtils.setField(jwtUtil, "expirationMs", 3600000);
+        AuthService authService = new AuthService(manager, jwtUtil);
+
+        String token = authService.login("alice", "password");
+
+        assertEquals("alice", jwtUtil.parseClaims(token).getSubject());
+    }
+}


### PR DESCRIPTION
## Summary
- add AuthServiceLoginTests to check JWT returned by login
- add AuthControllerLoginTests to verify /api/auth/login

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68686d49cb5483239ac44c535d0371b5