### PR TITLE
Add JWT user info endpoint

### DIFF
--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/config/SecurityConfig.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/login", "/api/auth/verify").permitAll()
+                        .requestMatchers("/api/auth/login", "/api/auth/verify", "/api/auth/user").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(sess -> sess

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerVerifyTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerVerifyTests.java
@@ -1,6 +1,7 @@
 package com.myorg.hackerplatform.auth;
 
 import com.myorg.hackerplatform.jwt.JwtUtil;
+import com.myorg.hackerplatform.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -29,6 +30,9 @@ class AuthControllerVerifyTests {
 
     @MockBean
     private AuthService authService;
+
+    @MockBean
+    private UserRepository userRepository;
 
     @Autowired
     private JwtUtil jwtUtil;


### PR DESCRIPTION
## Summary
- add UserRepository injection to AuthController
- implement `/api/auth/user` to validate JWT and return user details from DB
- permit the new endpoint in security config
- add tests for the new endpoint

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6868744923bc83238e60c21da34f9e3e