### PR TITLE
Add DatabaseUserDetailsService and configure password encoder

### DIFF
--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/service/DatabaseUserDetailsService.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/service/DatabaseUserDetailsService.java
@@ -8,10 +8,10 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Service;
 
 @Service
-public class CustomUserDetailsService implements UserDetailsService {
+public class DatabaseUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
-    public CustomUserDetailsService(UserRepository userRepository) {
+    public DatabaseUserDetailsService(UserRepository userRepository) {
         this.userRepository = userRepository;
     }
 


### PR DESCRIPTION
## Summary
- rename CustomUserDetailsService to DatabaseUserDetailsService
- expose a BCryptPasswordEncoder bean through `SecurityConfig`
- wire the encoder into `AuthenticationManager`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_686875a20448832382bc0e5b85b7613a