### PR TITLE
Add login page and routing link

### DIFF
--- a/HackerPlatform-UI/app/login/page.tsx
+++ b/HackerPlatform-UI/app/login/page.tsx
@@ -1,48 +1,33 @@
 'use client';
-import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 export default function LoginPage() {
   const router = useRouter();
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState('');
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
-    setError('');
+    const form = e.currentTarget;
     const res = await fetch('/api/auth/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ username, password })
+      body: JSON.stringify({
+        username: form.username.value,
+        password: form.password.value,
+      }),
     });
-    if (res.ok) {
-      router.push('/dashboard');
-    } else {
-      setError('Login failed');
-    }
+    if (res.ok) router.push('/dashboard');
   }
 
   return (
     <form onSubmit={handleSubmit}>
       <div>
         <label htmlFor="username">Username:</label>
-        <input
-          id="username"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
-        />
+        <input id="username" name="username" autoFocus />
       </div>
       <div>
         <label htmlFor="password">Password:</label>
-        <input
-          id="password"
-          type="password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
+        <input id="password" type="password" name="password" />
       </div>
-      {error && <p>{error}</p>}
       <button type="submit">Login</button>
     </form>
   );

--- a/HackerPlatform-UI/app/page.tsx
+++ b/HackerPlatform-UI/app/page.tsx
@@ -1,3 +1,10 @@
+import Link from 'next/link';
+
 export default function Home() {
-  return <h1>Welcome to HackerPlatform</h1>;
+  return (
+    <div>
+      <h1>Welcome to HackerPlatform</h1>
+      <Link href="/login">Login</Link>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add a login page with a form that posts to `/api/auth/login`
- redirect to `/dashboard` when login succeeds
- expose a login link from the home page

## Testing
- `npm run build` in `HackerPlatform-UI`

------
https://chatgpt.com/codex/tasks/task_e_68687712ade0832395c9cceaf4eb5936