### PR TITLE
Add API_URL setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ property so no additional configuration is required.
 
 The Next.js UI lives under `HackerPlatform-UI`.
 
+Before running the frontend you must tell it where the backend is located. Define
+an `API_URL` environment variable pointing at your backend. The easiest way is
+to create a `.env.local` file inside `HackerPlatform-UI` with the line:
+
+```bash
+API_URL=http://localhost:8080
+```
+
+Adjust the URL if your backend runs elsewhere.
+
 Install dependencies once:
 
 ```bash


### PR DESCRIPTION
## Summary
- explain how to define `API_URL` for the frontend via `.env.local`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6868782bac0c8323bff813b774fa97bc