### PR TITLE
Add refresh token support and logout route

### DIFF
--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/auth/AuthController.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/auth/AuthController.java
@@ -4,6 +4,7 @@ import com.myorg.hackerplatform.service.AuthService;
 import com.myorg.hackerplatform.jwt.JwtUtil;
 import com.myorg.hackerplatform.repository.UserRepository;
 import com.myorg.hackerplatform.model.User;
+import com.myorg.hackerplatform.auth.AuthTokens;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import org.springframework.http.HttpHeaders;
@@ -25,7 +26,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public String login(@RequestBody AuthRequest req) {
+    public AuthTokens login(@RequestBody AuthRequest req) {
         return authService.login(req.getUsername(), req.getPassword());
     }
 

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/auth/AuthTokens.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/auth/AuthTokens.java
@@ -1,0 +1,3 @@
+package com.myorg.hackerplatform.auth;
+
+public record AuthTokens(String accessToken, String refreshToken) {}

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/jwt/JwtUtil.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/jwt/JwtUtil.java
@@ -16,6 +16,9 @@ public class JwtUtil {
     @Value("${jwt.expirationMs}")
     private int expirationMs;
 
+    @Value("${jwt.refreshExpirationMs}")
+    private int refreshExpirationMs;
+
     private SecretKey getSigningKey() {
         return Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
     }
@@ -23,6 +26,17 @@ public class JwtUtil {
     public String generateToken(String username) {
         Date now = new Date();
         Date exp = new Date(now.getTime() + expirationMs);
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(now)
+                .setExpiration(exp)
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(String username) {
+        Date now = new Date();
+        Date exp = new Date(now.getTime() + refreshExpirationMs);
         return Jwts.builder()
                 .setSubject(username)
                 .setIssuedAt(now)

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/service/AuthService.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.myorg.hackerplatform.service;
 
 import com.myorg.hackerplatform.jwt.JwtUtil;
+import com.myorg.hackerplatform.auth.AuthTokens;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -16,10 +17,12 @@ public class AuthService {
         this.jwtUtil = jwtUtil;
     }
 
-    public String login(String username, String password) {
+    public AuthTokens login(String username, String password) {
         Authentication auth = authManager.authenticate(
                 new UsernamePasswordAuthenticationToken(username, password)
         );
-        return jwtUtil.generateToken(auth.getName());
+        String access = jwtUtil.generateToken(auth.getName());
+        String refresh = jwtUtil.generateRefreshToken(auth.getName());
+        return new AuthTokens(access, refresh);
     }
 }

--- a/HackerPlatform-Backend/src/main/resources/application.properties
+++ b/HackerPlatform-Backend/src/main/resources/application.properties
@@ -2,6 +2,7 @@ spring.application.name=HackerPlatform-Backend
 
 # JWT configuration
 jwt.expirationMs=3600000
+jwt.refreshExpirationMs=604800000
 
 # Spring Security OAuth2 Resource Server (decoding JWTs)
 spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8080

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerLoginTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerLoginTests.java
@@ -1,6 +1,7 @@
 package com.myorg.hackerplatform.auth;
 
 import com.myorg.hackerplatform.jwt.JwtUtil;
+import com.myorg.hackerplatform.auth.AuthTokens;
 import com.myorg.hackerplatform.service.AuthService;
 import com.myorg.hackerplatform.repository.UserRepository;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(AuthControllerLoginTests.TestConfig.class)
-@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000"})
+@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000", "jwt.refreshExpirationMs=604800000"})
 class AuthControllerLoginTests {
 
     @Autowired
@@ -38,13 +39,14 @@ class AuthControllerLoginTests {
 
     @Test
     void loginValidUserReturns200() throws Exception {
-        when(authService.login(eq("alice"), eq("password"))).thenReturn("token");
+        when(authService.login(eq("alice"), eq("password")))
+                .thenReturn(new AuthTokens("access", "refresh"));
 
         mockMvc.perform(post("/api/auth/login")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"username\":\"alice\",\"password\":\"password\"}"))
                 .andExpect(status().isOk())
-                .andExpect(content().string("token"));
+                .andExpect(content().json("{\"accessToken\":\"access\",\"refreshToken\":\"refresh\"}"));
     }
 
     static class TestConfig {
@@ -53,6 +55,7 @@ class AuthControllerLoginTests {
             JwtUtil util = new JwtUtil();
             ReflectionTestUtils.setField(util, "secret", "lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=");
             ReflectionTestUtils.setField(util, "expirationMs", 3600000);
+            ReflectionTestUtils.setField(util, "refreshExpirationMs", 604800000);
             return util;
         }
     }

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerUserDetailsTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerUserDetailsTests.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(AuthControllerUserDetailsTests.TestConfig.class)
-@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000"})
+@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000", "jwt.refreshExpirationMs=604800000"})
 class AuthControllerUserDetailsTests {
 
     @Autowired
@@ -70,6 +70,7 @@ class AuthControllerUserDetailsTests {
             JwtUtil util = new JwtUtil();
             ReflectionTestUtils.setField(util, "secret", "lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=");
             ReflectionTestUtils.setField(util, "expirationMs", 3600000);
+            ReflectionTestUtils.setField(util, "refreshExpirationMs", 604800000);
             return util;
         }
     }

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerVerifyTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerVerifyTests.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(AuthControllerVerifyTests.TestConfig.class)
-@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000"})
+@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000", "jwt.refreshExpirationMs=604800000"})
 class AuthControllerVerifyTests {
 
     @Autowired
@@ -59,6 +59,7 @@ class AuthControllerVerifyTests {
             JwtUtil util = new JwtUtil();
             ReflectionTestUtils.setField(util, "secret", "lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=");
             ReflectionTestUtils.setField(util, "expirationMs", 3600000);
+            ReflectionTestUtils.setField(util, "refreshExpirationMs", 604800000);
             return util;
         }
     }

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/service/AuthServiceLoginTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/service/AuthServiceLoginTests.java
@@ -15,10 +15,12 @@ class AuthServiceLoginTests {
         JwtUtil jwtUtil = new JwtUtil();
         ReflectionTestUtils.setField(jwtUtil, "secret", "lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=");
         ReflectionTestUtils.setField(jwtUtil, "expirationMs", 3600000);
+        ReflectionTestUtils.setField(jwtUtil, "refreshExpirationMs", 604800000);
         AuthService authService = new AuthService(manager, jwtUtil);
 
-        String token = authService.login("alice", "password");
+        var tokens = authService.login("alice", "password");
 
-        assertEquals("alice", jwtUtil.parseClaims(token).getSubject());
+        assertEquals("alice", jwtUtil.parseClaims(tokens.accessToken()).getSubject());
+        assertEquals("alice", jwtUtil.parseClaims(tokens.refreshToken()).getSubject());
     }
 }

--- a/HackerPlatform-UI/app/api/auth/login/route.ts
+++ b/HackerPlatform-UI/app/api/auth/login/route.ts
@@ -8,8 +8,14 @@ export async function POST(req: Request) {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ username, password })
   });
-  const token = await res.text();
-  cookies().set('accessToken', token, {
+  const { accessToken, refreshToken } = await res.json();
+  cookies().set('accessToken', accessToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+    path: '/'
+  });
+  cookies().set('refreshToken', refreshToken, {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'strict',

--- a/HackerPlatform-UI/app/api/auth/logout/route.ts
+++ b/HackerPlatform-UI/app/api/auth/logout/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+export async function POST() {
+  cookies().delete('accessToken');
+  cookies().delete('refreshToken');
+  return NextResponse.json({ success: true });
+}


### PR DESCRIPTION
## Summary
- issue refresh tokens from AuthService
- return both tokens from `/api/auth/login`
- add new `/api/auth/logout` route in the Next.js frontend
- persist refresh token setting and update tests

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68687a984d508323a194d7b4dad5994a