### PR TITLE
Add session validation endpoint

### DIFF
--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/auth/AuthController.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/auth/AuthController.java
@@ -72,4 +72,30 @@ public class AuthController {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
         }
     }
+
+    // Validates the provided JWT and returns the associated user details
+    @GetMapping("/validate")
+    public ResponseEntity<?> validate(@RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization) {
+        if (authorization == null || !authorization.startsWith("Bearer ")) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+        String token = authorization.substring(7);
+        try {
+            Claims claims = jwtUtil.parseClaims(token);
+            String username = claims.getSubject();
+            return userRepository.findByUsername(username)
+                    .map(user -> ResponseEntity.ok(
+                            java.util.Map.of(
+                                    "user",
+                                    java.util.Map.of(
+                                            "id", user.getId(),
+                                            "username", user.getUsername()
+                                    )
+                            )
+                    ))
+                    .orElseGet(() -> ResponseEntity.status(HttpStatus.UNAUTHORIZED).build());
+        } catch (JwtException | IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+    }
 }

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/config/SecurityConfig.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/config/SecurityConfig.java
@@ -21,7 +21,7 @@ public class SecurityConfig {
         http
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/login", "/api/auth/verify", "/api/auth/user").permitAll()
+                        .requestMatchers("/api/auth/login", "/api/auth/verify", "/api/auth/user", "/api/auth/validate").permitAll()
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(sess -> sess

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerValidateTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerValidateTests.java
@@ -1,0 +1,77 @@
+package com.myorg.hackerplatform.auth;
+
+import com.myorg.hackerplatform.jwt.JwtUtil;
+import com.myorg.hackerplatform.model.User;
+import com.myorg.hackerplatform.repository.UserRepository;
+import com.myorg.hackerplatform.service.AuthService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import(AuthControllerValidateTests.TestConfig.class)
+@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000", "jwt.refreshExpirationMs=604800000"})
+class AuthControllerValidateTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+    @Test
+    void validateValidTokenReturnsUserDetails() throws Exception {
+        String token = jwtUtil.generateToken("alice");
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("alice");
+        when(userRepository.findByUsername(eq("alice"))).thenReturn(Optional.of(user));
+
+        mockMvc.perform(get("/api/auth/validate")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user.id").value(1))
+                .andExpect(jsonPath("$.user.username").value("alice"));
+    }
+
+    @Test
+    void validateInvalidTokenReturnsUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/auth/validate")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer bad"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    static class TestConfig {
+        @Bean
+        JwtUtil jwtUtil() {
+            JwtUtil util = new JwtUtil();
+            ReflectionTestUtils.setField(util, "secret", "lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=");
+            ReflectionTestUtils.setField(util, "expirationMs", 3600000);
+            ReflectionTestUtils.setField(util, "refreshExpirationMs", 604800000);
+            return util;
+        }
+    }
+}

--- a/HackerPlatform-UI/app/lib/dal.ts
+++ b/HackerPlatform-UI/app/lib/dal.ts
@@ -5,7 +5,7 @@ export const verifySession = cache(async () => {
   const token = cookies().get('accessToken')?.value;
   if (!token) return null;
   try {
-    const res = await fetch(`${process.env.API_URL}/api/auth/verify`, {
+    const res = await fetch(`${process.env.API_URL}/api/auth/validate`, {
       headers: { Authorization: `Bearer ${token}` }
     });
     return res.ok ? await res.json() : null;


### PR DESCRIPTION
## Summary
- add `/api/auth/validate` endpoint that validates JWT and returns user details
- expose new endpoint in security config
- update frontend `verifySession` to call the new route
- add tests for the validation endpoint

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_6868a66e978c8323b0fb8c7aa89c9781