### PR TITLE
Implement refresh token functionality

### DIFF
--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/auth/RefreshRequest.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/HackerPlatform/auth/RefreshRequest.java
@@ -1,0 +1,13 @@
+package com.myorg.hackerplatform.auth;
+
+public class RefreshRequest {
+    private String refreshToken;
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/model/RefreshToken.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/model/RefreshToken.java
@@ -1,0 +1,55 @@
+package com.myorg.hackerplatform.model;
+
+import jakarta.persistence.*;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "refresh_tokens")
+public class RefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private Instant expiryDate;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+
+    public Instant getExpiryDate() {
+        return expiryDate;
+    }
+
+    public void setExpiryDate(Instant expiryDate) {
+        this.expiryDate = expiryDate;
+    }
+}

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/repository/RefreshTokenRepository.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.myorg.hackerplatform.repository;
+
+import com.myorg.hackerplatform.model.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByToken(String token);
+}

--- a/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/service/RefreshTokenService.java
+++ b/HackerPlatform-Backend/src/main/java/com/myorg/hackerplatform/service/RefreshTokenService.java
@@ -1,0 +1,40 @@
+package com.myorg.hackerplatform.service;
+
+import com.myorg.hackerplatform.model.RefreshToken;
+import com.myorg.hackerplatform.model.User;
+import com.myorg.hackerplatform.repository.RefreshTokenRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${jwt.refreshExpirationMs}")
+    private long refreshTokenDurationMs;
+
+    public RefreshTokenService(RefreshTokenRepository refreshTokenRepository) {
+        this.refreshTokenRepository = refreshTokenRepository;
+    }
+
+    public RefreshToken createRefreshToken(User user) {
+        RefreshToken refreshToken = new RefreshToken();
+        refreshToken.setUser(user);
+        refreshToken.setToken(UUID.randomUUID().toString());
+        refreshToken.setExpiryDate(Instant.now().plusMillis(refreshTokenDurationMs));
+        return refreshTokenRepository.save(refreshToken);
+    }
+
+    public Optional<RefreshToken> validateRefreshToken(String token) {
+        return refreshTokenRepository.findByToken(token)
+                .filter(rt -> rt.getExpiryDate().isAfter(Instant.now()));
+    }
+
+    public void deleteRefreshToken(String token) {
+        refreshTokenRepository.findByToken(token).ifPresent(refreshTokenRepository::delete);
+    }
+}

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerLoginTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerLoginTests.java
@@ -37,6 +37,9 @@ class AuthControllerLoginTests {
     @MockBean
     private UserRepository userRepository;
 
+    @MockBean
+    private com.myorg.hackerplatform.service.RefreshTokenService refreshTokenService;
+
     @Test
     void loginValidUserReturns200() throws Exception {
         when(authService.login(eq("alice"), eq("password")))
@@ -60,3 +63,4 @@ class AuthControllerLoginTests {
         }
     }
 }
+

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerValidateTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerValidateTests.java
@@ -39,6 +39,9 @@ class AuthControllerValidateTests {
     @MockBean
     private UserRepository userRepository;
 
+    @MockBean
+    private com.myorg.hackerplatform.service.RefreshTokenService refreshTokenService;
+
     @Autowired
     private JwtUtil jwtUtil;
 
@@ -75,3 +78,4 @@ class AuthControllerValidateTests {
         }
     }
 }
+

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerVerifyTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerVerifyTests.java
@@ -34,6 +34,9 @@ class AuthControllerVerifyTests {
     @MockBean
     private UserRepository userRepository;
 
+    @MockBean
+    private com.myorg.hackerplatform.service.RefreshTokenService refreshTokenService;
+
     @Autowired
     private JwtUtil jwtUtil;
 
@@ -64,3 +67,4 @@ class AuthControllerVerifyTests {
         }
     }
 }
+

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/service/AuthServiceLoginTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/service/AuthServiceLoginTests.java
@@ -1,9 +1,13 @@
 package com.myorg.hackerplatform.service;
 
 import com.myorg.hackerplatform.jwt.JwtUtil;
+import com.myorg.hackerplatform.model.User;
+import com.myorg.hackerplatform.repository.RefreshTokenRepository;
+import com.myorg.hackerplatform.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -16,11 +20,24 @@ class AuthServiceLoginTests {
         ReflectionTestUtils.setField(jwtUtil, "secret", "lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=");
         ReflectionTestUtils.setField(jwtUtil, "expirationMs", 3600000);
         ReflectionTestUtils.setField(jwtUtil, "refreshExpirationMs", 604800000);
-        AuthService authService = new AuthService(manager, jwtUtil);
+
+        UserRepository userRepository = Mockito.mock(UserRepository.class);
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("alice");
+        Mockito.when(userRepository.findByUsername("alice")).thenReturn(java.util.Optional.of(user));
+
+        RefreshTokenRepository tokenRepo = Mockito.mock(RefreshTokenRepository.class);
+        Mockito.when(tokenRepo.save(Mockito.any())).thenAnswer(inv -> inv.getArgument(0));
+        RefreshTokenService refreshTokenService = new RefreshTokenService(tokenRepo);
+        ReflectionTestUtils.setField(refreshTokenService, "refreshTokenDurationMs", 604800000L);
+
+        AuthService authService = new AuthService(manager, jwtUtil, userRepository, refreshTokenService);
 
         var tokens = authService.login("alice", "password");
 
         assertEquals("alice", jwtUtil.parseClaims(tokens.accessToken()).getSubject());
-        assertEquals("alice", jwtUtil.parseClaims(tokens.refreshToken()).getSubject());
+        // refresh token should be generated and not empty
+        org.junit.jupiter.api.Assertions.assertFalse(tokens.refreshToken().isEmpty());
     }
 }

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/service/RefreshTokenServiceTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/service/RefreshTokenServiceTests.java
@@ -1,0 +1,53 @@
+package com.myorg.hackerplatform.service;
+
+import com.myorg.hackerplatform.model.RefreshToken;
+import com.myorg.hackerplatform.model.User;
+import com.myorg.hackerplatform.repository.RefreshTokenRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class RefreshTokenServiceTests {
+
+    @Test
+    void createAndValidateToken() {
+        RefreshTokenRepository repo = mock(RefreshTokenRepository.class);
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        RefreshTokenService service = new RefreshTokenService(repo);
+        ReflectionTestUtils.setField(service, "refreshTokenDurationMs", 1000L);
+
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("alice");
+
+        RefreshToken token = service.createRefreshToken(user);
+        when(repo.findByToken(token.getToken())).thenReturn(Optional.of(token));
+
+        Optional<RefreshToken> validated = service.validateRefreshToken(token.getToken());
+        assertTrue(validated.isPresent());
+        assertEquals(user, validated.get().getUser());
+    }
+
+    @Test
+    void expiredTokenFailsValidation() {
+        RefreshTokenRepository repo = mock(RefreshTokenRepository.class);
+        when(repo.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        RefreshTokenService service = new RefreshTokenService(repo);
+        ReflectionTestUtils.setField(service, "refreshTokenDurationMs", 0L);
+
+        User user = new User();
+        user.setId(1L);
+        user.setUsername("alice");
+
+        RefreshToken token = service.createRefreshToken(user);
+        when(repo.findByToken(token.getToken())).thenReturn(Optional.of(token));
+
+        Optional<RefreshToken> validated = service.validateRefreshToken(token.getToken());
+        assertFalse(validated.isPresent());
+    }
+}
+


### PR DESCRIPTION
## Summary
- add `RefreshToken` JPA entity and repository
- implement `RefreshTokenService`
- generate refresh tokens in `AuthService`
- extend `AuthController` with refresh/logout endpoints
- add DTO for refresh requests
- update and add unit tests for refresh token support

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6869448de9f48323b3c19a278ea570eb