### PR TITLE
Implement refresh token flow

### DIFF
--- a/HackerPlatform-UI/app/api/auth/logout/route.ts
+++ b/HackerPlatform-UI/app/api/auth/logout/route.ts
@@ -2,7 +2,16 @@ import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 
 export async function POST() {
-  cookies().delete('accessToken');
-  cookies().delete('refreshToken');
+  const cookieStore = cookies();
+  const refreshToken = cookieStore.get('refreshToken')?.value;
+  if (refreshToken) {
+    await fetch(`${process.env.API_URL}/api/auth/logout`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refreshToken })
+    });
+  }
+  cookieStore.delete('accessToken');
+  cookieStore.delete('refreshToken');
   return NextResponse.json({ success: true });
 }

--- a/HackerPlatform-UI/app/api/auth/refresh/route.ts
+++ b/HackerPlatform-UI/app/api/auth/refresh/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+export async function POST() {
+  const cookieStore = cookies();
+  const refreshToken = cookieStore.get('refreshToken')?.value;
+  if (!refreshToken) {
+    return NextResponse.json({ error: 'Missing refresh token' }, { status: 401 });
+  }
+
+  const res = await fetch(`${process.env.API_URL}/api/auth/refresh`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refreshToken })
+  });
+
+  if (!res.ok) {
+    cookieStore.delete('accessToken');
+    cookieStore.delete('refreshToken');
+    return NextResponse.json({ error: 'Unable to refresh' }, { status: res.status });
+  }
+
+  const { accessToken, refreshToken: newRefresh } = await res.json();
+
+  cookieStore.set('accessToken', accessToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+    path: '/'
+  });
+  cookieStore.set('refreshToken', newRefresh, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'strict',
+    path: '/'
+  });
+
+  return NextResponse.json({ accessToken, refreshToken: newRefresh });
+}

--- a/HackerPlatform-UI/app/lib/dal.ts
+++ b/HackerPlatform-UI/app/lib/dal.ts
@@ -1,14 +1,28 @@
 import { cache } from 'react';
 import { cookies } from 'next/headers';
+import { POST as refreshTokens } from '../api/auth/refresh/route';
 
 export const verifySession = cache(async () => {
-  const token = cookies().get('accessToken')?.value;
+  const cookieStore = cookies();
+  let token = cookieStore.get('accessToken')?.value;
   if (!token) return null;
   try {
-    const res = await fetch(`${process.env.API_URL}/api/auth/validate`, {
+    let res = await fetch(`${process.env.API_URL}/api/auth/validate`, {
       headers: { Authorization: `Bearer ${token}` }
     });
-    return res.ok ? await res.json() : null;
+    if (res.ok) return await res.json();
+    if (res.status === 401) {
+      const refreshRes = await refreshTokens();
+      if (refreshRes.ok) {
+        const { accessToken } = await refreshRes.json();
+        token = accessToken;
+        res = await fetch(`${process.env.API_URL}/api/auth/validate`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        if (res.ok) return await res.json();
+      }
+    }
+    return null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- add `app/api/auth/refresh` route to refresh tokens
- update logout handler to notify the backend
- update `verifySession` to refresh tokens on 401

## Testing
- `npm run build` within `HackerPlatform-UI`
- `./gradlew test` within `HackerPlatform-Backend`


------
https://chatgpt.com/codex/tasks/task_e_6869468c50d48323a28f527fb02b93fd