### PR TITLE
Update JWT secret config and docs

### DIFF
--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerLoginTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerLoginTests.java
@@ -25,7 +25,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(AuthControllerLoginTests.TestConfig.class)
-@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000", "jwt.refreshExpirationMs=604800000"})
+@TestPropertySource(properties = {"JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000", "jwt.refreshExpirationMs=604800000"})
 class AuthControllerLoginTests {
 
     @Autowired

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerRefreshTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerRefreshTests.java
@@ -31,7 +31,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(AuthControllerRefreshTests.TestConfig.class)
-@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000", "jwt.refreshExpirationMs=604800000"})
+@TestPropertySource(properties = {"JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000", "jwt.refreshExpirationMs=604800000"})
 class AuthControllerRefreshTests {
 
     @Autowired

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerUserDetailsTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerUserDetailsTests.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(AuthControllerUserDetailsTests.TestConfig.class)
-@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000", "jwt.refreshExpirationMs=604800000"})
+@TestPropertySource(properties = {"JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000", "jwt.refreshExpirationMs=604800000"})
 class AuthControllerUserDetailsTests {
 
     @Autowired

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerValidateTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerValidateTests.java
@@ -27,7 +27,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(AuthControllerValidateTests.TestConfig.class)
-@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000", "jwt.refreshExpirationMs=604800000"})
+@TestPropertySource(properties = {"JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000", "jwt.refreshExpirationMs=604800000"})
 class AuthControllerValidateTests {
 
     @Autowired

--- a/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerVerifyTests.java
+++ b/HackerPlatform-Backend/src/test/java/com/myorg/hackerplatform/auth/AuthControllerVerifyTests.java
@@ -22,7 +22,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @WebMvcTest(AuthController.class)
 @AutoConfigureMockMvc(addFilters = false)
 @Import(AuthControllerVerifyTests.TestConfig.class)
-@TestPropertySource(properties = {"jwt.secret=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000", "jwt.refreshExpirationMs=604800000"})
+@TestPropertySource(properties = {"JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "JWT_SECRET=lw8Jk7ZQHtN4+ov2X3KqFv8JrW4dKC5gG5tf1x8b1Qs=", "jwt.expirationMs=3600000", "jwt.refreshExpirationMs=604800000"})
 class AuthControllerVerifyTests {
 
     @Autowired

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The service will start locally on the default port.
 
 ## Configuration
 
-The backend expects a signing key through the `jwt.secret` property. During
+The backend expects a signing key through the `JWT_SECRET` property. During
 development you can provide it by exporting an environment variable named
 `JWT_SECRET` before starting the application:
 
@@ -49,8 +49,18 @@ export JWT_SECRET=<your-base64-secret>
 ./gradlew bootRun
 ```
 
-Spring Boot automatically maps the `JWT_SECRET` variable to the `jwt.secret`
-property so no additional configuration is required.
+Spring Boot reads the `JWT_SECRET` variable directly, so no additional configuration is required.
+
+## Authentication Endpoints
+
+The backend exposes several endpoints under `/api/auth`:
+
+- `POST /api/auth/login` – obtain an access and refresh token pair.
+- `GET /api/auth/verify` – validate the current access token and session.
+- `GET /api/auth/user` – retrieve details for the authenticated user.
+- `GET /api/auth/validate` – returns user details if the token is valid.
+- `POST /api/auth/refresh` – **new** endpoint that issues a new access token using a valid refresh token.
+- `POST /api/auth/logout` – **new** endpoint that invalidates the provided refresh token.
 
 ## Frontend Development
 


### PR DESCRIPTION
## Summary
- update README with new property name and mention `/refresh` and `/logout`
- replace `jwt.secret` references in tests with `JWT_SECRET`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68694844ac548323ae93d5f3baeaa7ca